### PR TITLE
Add version to Info Menu (#10)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,9 +2,9 @@ name: CMake
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -21,6 +21,21 @@ jobs:
     - uses: actions/checkout@v3
       with:
          submodules: 'recursive'
+         fetch-depth: '0'
+    - run: |
+        git fetch origin --tags --force
+        TAG=$(git describe --tags --exact-match HEAD --exclude=latest --exclude=nightly) || true
+        if [ $TAG ]
+        then
+          echo "SD2PSX_VERSION=${TAG}" >> $GITHUB_ENV
+          echo "SD2PSX_RLS_TAG=latest" >> $GITHUB_ENV
+          echo "${TAG}"
+        else
+          echo "SD2PSX_VERSION=nightly-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "SD2PSX_RLS_TAG=nightly" >> $GITHUB_ENV
+          echo "nightly"
+        fi
+      
     - name: add build essential
       run: sudo apt update && sudo apt install -y build-essential gcc-arm-none-eabi
 
@@ -46,15 +61,15 @@ jobs:
       
     - name: Rename Debug USB uf2
       run: mv build_usb/sd2psx.uf2 build/sd2psx_usb_debug.uf2
-      
 
     - uses: marvinpinto/action-automatic-releases@v1.2.1
       if: github.event_name != 'pull_request'
       # uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0
       with:
         # GitHub secret token
+        title:  "${{ env.SD2PSX_VERSION }}"
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: latest
+        automatic_release_tag: ${{ env.SD2PSX_RLS_TAG }}
         prerelease: true
         # Assets to upload to the release
         files: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ build
 .vscode
 keys.c
 .cache
-gamedbps*.dat

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,8 @@ add_subdirectory(ext/lvgl EXCLUDE_FROM_ALL)
 
 add_subdirectory(database)
 add_subdirectory(ps2boot)
+add_subdirectory(src/version)
 
-                
 add_executable(sd2psx
     src/main.c
     src/debug.c
@@ -133,6 +133,7 @@ target_link_libraries(sd2psx
     lvgl::lvgl
     gamedb
     ps2boot
+    sd2psx_version
 )
 
 add_dependencies(sd2psx gamedb ps2boot)

--- a/src/gui.c
+++ b/src/gui.c
@@ -20,6 +20,8 @@
 #include "ps2/ps2_dirty.h"
 #include "ps2/ps2_exploit.h"
 
+#include "version/version.h"
+
 #include "ui_theme_mono.h"
 
 /* Displays the line at the bottom for long pressing buttons */
@@ -589,6 +591,26 @@ static void create_menu_screen(void) {
         lv_obj_add_event_cb(cont, evt_do_civ_deploy, LV_EVENT_CLICKED, NULL);
     }
 
+    /* Info submenu */
+    lv_obj_t *info_page = ui_menu_subpage_create(menu, "Info");
+    {
+        cont = ui_menu_cont_create_nav(info_page);
+        ui_label_create_grow_scroll(cont, "Version");
+        ui_label_create(cont, sd2psx_version);
+
+        cont = ui_menu_cont_create_nav(info_page);
+        ui_label_create_grow_scroll(cont, "Commit");
+        ui_label_create(cont, sd2psx_commit);
+
+        cont = ui_menu_cont_create_nav(info_page);
+        ui_label_create_grow_scroll(cont, "Debug");
+#ifdef DEBUG_USB_UART
+        ui_label_create(cont, "Yes");
+#else
+        ui_label_create(cont, "No");
+#endif
+    }
+
     /* Main menu */
     main_page = ui_menu_subpage_create(menu, NULL);
     {
@@ -611,6 +633,12 @@ static void create_menu_screen(void) {
         ui_label_create_grow(cont, "Display");
         ui_label_create(cont, ">");
         ui_menu_set_load_page_event(menu, cont, display_page);
+
+        cont = ui_menu_cont_create_nav(main_page);
+        ui_label_create_grow_scroll(cont, "Info");
+        ui_label_create(cont, ">");
+        ui_menu_set_load_page_event(menu, cont, info_page);
+
     }
 
     ui_menu_set_page(menu, main_page);

--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,7 @@
 #include "sd.h"
 #include "keystore.h"
 #include "settings.h"
+#include "version/version.h"
 
 #include "ps1/ps1_memory_card.h"
 #include "ps1/ps1_dirty.h"
@@ -125,6 +126,7 @@ int main() {
         gui_do_ps2_card_switch();
         uint64_t end = time_us_64();
         printf("DONE! (%d us)\n", (int)(end - start));
+        printf("SD2PSX Version %s\n", sd2psx_version);
 
         while (1) {
             debug_task();

--- a/src/version/CMakeLists.txt
+++ b/src/version/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_custom_target(sd2psx_version_generator ALL 
+                    COMMAND ${CMAKE_COMMAND} 
+                        -D SCRIPT_TEMPLATE=${CMAKE_CURRENT_SOURCE_DIR}/template/version.c 
+                        -D SCRIPT_WORKING_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+                        -D SCRIPT_OUTPUT_FILE=${CMAKE_CURRENT_BINARY_DIR}/version.c
+                        -P ${CMAKE_CURRENT_SOURCE_DIR}/script.cmake
+                    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/version.c)
+
+add_library(sd2psx_version STATIC ${CMAKE_CURRENT_BINARY_DIR}/version.c)
+target_include_directories(sd2psx_version PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/version/script.cmake
+++ b/src/version/script.cmake
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.12)
+
+find_package(Git QUIET)
+
+if(Git_FOUND AND EXISTS "${SCRIPT_WORKING_DIR}/../../.git")
+    execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --exact-match HEAD --exclude=latest --exclude=nightly
+                    OUTPUT_VARIABLE SD2PSX_VERSION WORKING_DIRECTORY ${SCRIPT_WORKING_DIR}
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+                    OUTPUT_VARIABLE SD2PSX_COMMIT WORKING_DIRECTORY ${SCRIPT_WORKING_DIR}
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+                    OUTPUT_VARIABLE SD2PSX_BRANCH WORKING_DIRECTORY ${SCRIPT_WORKING_DIR}
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    string(REGEX REPLACE "\n$" "" SD2PSX_VERSION "${SD2PSX_VERSION}")
+    string(REGEX REPLACE "\n$" "" SD2PSX_COMMIT "${SD2PSX_COMMIT}")
+    string(REGEX REPLACE "\n$" "" SD2PSX_BRANCH "${SD2PSX_BRANCH}")
+    if("${SD2PSX_VERSION}" STREQUAL "")
+        set(SD2PSX_VERSION "nightly")
+    endif()
+else()
+    set(SD2PSX_VERSION "None")
+    set(SD2PSX_COMMIT "None")
+    set(SD2PSX_BRANCH "None")
+endif()
+
+file(READ ${SCRIPT_TEMPLATE} template_file)
+
+string(REPLACE "@SD2PSX_VERSION@" ${SD2PSX_VERSION} template_file "${template_file}")
+string(REPLACE "@SD2PSX_COMMIT@" ${SD2PSX_COMMIT} template_file "${template_file}")
+string(REPLACE "@SD2PSX_BRANCH@" ${SD2PSX_BRANCH} template_file "${template_file}")
+
+file(WRITE ${SCRIPT_OUTPUT_FILE} "${template_file}")

--- a/src/version/template/version.c
+++ b/src/version/template/version.c
@@ -1,0 +1,5 @@
+#include "version.h"
+
+const char* sd2psx_version = "@SD2PSX_VERSION@";
+const char* sd2psx_commit = "@SD2PSX_COMMIT@";
+const char* sd2psx_branch = "@SD2PSX_BRANCH@";

--- a/src/version/version.h
+++ b/src/version/version.h
@@ -1,0 +1,6 @@
+
+#pragma once
+
+extern const char* sd2psx_version;
+extern const char* sd2psx_commit;
+extern const char* sd2psx_branch;


### PR DESCRIPTION
* Add USB Debugging through UART

* Add USB Debug UF2

* put char when writing to uart

* wip-ps2 exploit

* Peroperly adding exploit screen

* wip - read from flash

* Fix wrong pointer to buffer

* Add exploit "BOOT" card and activate Boot

* Add USB Debugging through UART

* put char when writing to uart

* wip-ps2 exploit

* Peroperly adding exploit screen

* wip - read from flash

* Fix wrong pointer to buffer

* Add exploit "BOOT" card and activate Boot

* Re-Add Force Refresh

* integrate boot iamge, remove deploy dialog (preliminary)

* Build also develop

* Get Bootcard during build

* Fix download

* Remove exploit deployment

* Fix using other cards after boot

* Remove check for exploit available (it's always available)

* Fix Min Index

* Remove create exploit screen

* Remove commented code

* Simplify settings

* Remove comments and debug

* cleanup

* Switch bootcard to latest selected card on button press Only use one bootcard channel named "BootCard.mcb"

* Disable channels for boot card

* Switch to first card after boot also on short press

* Add version

* Add separate version page

* Add Version to workflow

* Fix Build

* Fix non Debug version

* Try to get version during checkout

* CI

* Move version.c into build folder as it is generated each build

* Fix versioning

* Release name for untagged releases "nightly-COMMIT_HASH"

* Exclude nightly for describe

* Use cmake script to generate version.c

* Remove fetch --all and add origin

* Generate Version file after each clean

* Generate C file on each build, regardless of changed content

* Simplify build script

* Fix gitignore

* Remove fetch tags from build phase

---------